### PR TITLE
Fix missing ID when creating entry

### DIFF
--- a/src/components/AddEntryModal.jsx
+++ b/src/components/AddEntryModal.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 
 // This modal will handle adding new diary entries.
 const AddEntryModal = ({ setShowModal, addEntry, entry }) => {
+  const [id, setId] = useState('');
   const [title, setTitle] = useState('');
   const [date, setDate] = useState('');
   const [imageUrl, setImageUrl] = useState('');
@@ -10,6 +11,7 @@ const AddEntryModal = ({ setShowModal, addEntry, entry }) => {
   // If an entry is passed in, populate the form with the existing data (for editing)
   useEffect(() => {
     if (entry) {
+      setId(entry.id);
       setTitle(entry.title);
       setDate(entry.date);
       setImageUrl(entry.imageUrl);
@@ -19,6 +21,7 @@ const AddEntryModal = ({ setShowModal, addEntry, entry }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    const finalId = id || crypto.randomUUID();
 
     // If no date is selected, set date to today's date
     const currentDate = new Date().toISOString().split('T')[0]; // Format: YYYY-MM-DD
@@ -35,6 +38,7 @@ const AddEntryModal = ({ setShowModal, addEntry, entry }) => {
 
     const updatedEntry = {
       ...entry, // Keep the same ID or other unchanged fields
+      id: finalId,
       title,
       date: finalDate,
       imageUrl: finalImageUrl,
@@ -49,27 +53,27 @@ const AddEntryModal = ({ setShowModal, addEntry, entry }) => {
       <div className="bg-white p-6 rounded-lg shadow-lg w-3/4 md:w-1/2">
         <h2 className="text-2xl font-bold mb-4">{entry ? 'Edit Entry' : 'Add New Entry'}</h2>
         <form onSubmit={handleSubmit}>
-          <input
+          <input name="form-title"
             className="border p-2 mb-2 w-full"
             type="text"
             placeholder="Title"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
           />
-          <input
+          <input name="form-date"
             className="border p-2 mb-2 w-full"
             type="date"
             value={date}
             onChange={(e) => setDate(e.target.value)}
           />
-          <input
+          <input name="form-imageurl"
             className="border p-2 mb-2 w-full"
             type="text"
             placeholder="Image URL"
             value={imageUrl}
             onChange={(e) => setImageUrl(e.target.value)}
           />
-          <textarea
+          <textarea name="form-content"
             className="border p-2 mb-2 w-full"
             placeholder="Content"
             value={content}

--- a/src/components/Themecontroller.jsx
+++ b/src/components/Themecontroller.jsx
@@ -1,8 +1,8 @@
 const Themecontroller = () => {
     return (
-        <label className="swap swap-rotate">
+        <label htmlFor="theme-controller" className="swap swap-rotate">
             {/* this hidden checkbox controls the state */}
-            <input type="checkbox" className="theme-controller" value="business" />
+            <input type="checkbox" id="theme-controller" className="theme-controller" value="business" />
 
             {/* sun icon */}
             <svg

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -8,8 +8,8 @@ const Homepage = ({entries, updateEntry}) => {
             <Hero entries={entries} />
             <main className="self-center w-full max-w-[80rem]">
                 <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 p-4">
-                    {entries.map((entry, index) => (
-                        <DiaryEntryCard key={index} entry={entry} updateEntry={updateEntry}  />
+                    {entries.map((entry) => (
+                        <DiaryEntryCard key={entry.id} entry={entry} updateEntry={updateEntry}  />
                     ))}
                 </section>
             </main>

--- a/src/pages/Homepage.jsx
+++ b/src/pages/Homepage.jsx
@@ -1,14 +1,21 @@
 import DiaryEntryCard from '../components/DiaryEntryCard.jsx';
 import Hero from '../components/Hero.jsx';
+import {useEffect, useState} from 'react';
 
 // This is the main page that will display all the diary entries and handle adding new entries
 const Homepage = ({entries, updateEntry}) => {
+    const [limitEntries, setLimitEntries] = useState([]);
+
+    useEffect(() => {
+        setLimitEntries(entries.slice(0, 12));
+    }, [entries])
+
     return (
         <>
             <Hero entries={entries} />
             <main className="self-center w-full max-w-[80rem]">
                 <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 p-4">
-                    {entries.map((entry) => (
+                    {limitEntries.map((entry) => (
                         <DiaryEntryCard key={entry.id} entry={entry} updateEntry={updateEntry}  />
                     ))}
                 </section>


### PR DESCRIPTION
This PR fixes:

- missing ID when creating an entry
- using the then created ID as key property when rendering cards onto the homepage
- adding missing name/id parameters into form elements for semantics

It also adds:

- rendering the first 12 elements of the localStorage Array onto the homepage. thus limiting the amount of entries shown.